### PR TITLE
Strip app parameter from YouTube URLs & some MailChimp tracking parameters

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -1,13 +1,22 @@
 function getStrippedUrl(url) {
- if (url.indexOf('utm_') > url.indexOf('?')) {
+  // Strip UTM parameters 
+  if (url.indexOf('utm_') > url.indexOf('?')) {
     url = url.replace(
         /([\?\&]utm_(reader|source|medium|campaign|content|term)=[^&#]+)/ig,
         '');
   }
+  
+  // Strip MailChimp parameters
+  if (url.indexOf('mc_eid') > url.indexOf('?') || url.indexOf('mc_cid') > url.indexOf('?')) {
+    url = url.replace(
+        /([\?\&](mc_cid|mc_eid)=[^&#]+)/ig,
+        '');
+  }
 
+  // Strip YouTube parameters
   if (url.indexOf('http://www.youtube.com/watch') == 0 ||
       url.indexOf('https://www.youtube.com/watch') == 0) {
-    url = url.replace(/([\?\&]feature=[^&#]+)/ig, '');
+    url = url.replace(/([\?\&](feature|app)=[^&#]+)/ig, '');
   }
 
   // If there were other query parameters, and the stripped ones were first,
@@ -36,6 +45,8 @@ chrome.webNavigation.onDOMContentLoaded.addListener(
   {
     url: [
       {queryContains: 'utm_'},
+      {queryContains: 'mc_cid'},
+      {queryContains: 'mc_eid'},
       {hostEquals: 'www.youtube.com', pathPrefix: '/watch'},
     ]
   });

--- a/extension/tests.html
+++ b/extension/tests.html
@@ -36,13 +36,17 @@
       'http://example.com/post': 'http://example.com/post',
       'http://example.com/post?foo=bar': 'http://example.com/post?foo=bar',
       'http://example.com/post?utm_source=src&utm_medium=medium&utm_campaign=campaign&utm_reader=feedly': 'http://example.com/post',
+      'http://example.com/post?mc_cid=1234&mc_eid=4321': 'http://example.com/post',
       'http://example.com/post?foo=bar&utm_source=src': 'http://example.com/post?foo=bar',
       'http://example.com/post?utm_source=src&foo=bar': 'http://example.com/post?foo=bar',
       'http://example.com/post?utm_source=src#foo=bar': 'http://example.com/post#foo=bar',
 
       'https://www.youtube.com/watch?v=YlGqN3AKOsA&feature=kp': 'https://www.youtube.com/watch?v=YlGqN3AKOsA',
       'https://www.youtube.com/watch?feature=youtu.be&v=YlGqN3AKOsA': 'https://www.youtube.com/watch?v=YlGqN3AKOsA',
-      'http://www.youtube.com/watch?v=YlGqN3AKOsA&feature=kp': 'http://www.youtube.com/watch?v=YlGqN3AKOsA'
+      'http://www.youtube.com/watch?v=YlGqN3AKOsA&feature=kp': 'http://www.youtube.com/watch?v=YlGqN3AKOsA',
+      'http://www.youtube.com/watch?v=YlGqN3AKOsA&app=desktop': 'http://www.youtube.com/watch?v=YlGqN3AKOsA',
+      'http://www.youtube.com/watch?v=YlGqN3AKOsA&feature=kp&app=desktop': 'http://www.youtube.com/watch?v=YlGqN3AKOsA',
+      'http://www.youtube.com/watch?app=desktop&v=YlGqN3AKOsA': 'http://www.youtube.com/watch?v=YlGqN3AKOsA',      
     }
 
     function runTests() {


### PR DESCRIPTION
When you open a 'm.youtube.com' URL on desktop, you are redirected to 'www.youtube.com' and it adds the '&app=desktop' parameter.
