### PR TITLE
Add stripping of YouTube 'ac' parameter and fix test page

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -1,11 +1,11 @@
 function getStrippedUrl(url) {
-  // Strip UTM parameters 
+  // Strip UTM parameters
   if (url.indexOf('utm_') > url.indexOf('?')) {
     url = url.replace(
         /([\?\&]utm_(reader|source|medium|campaign|content|term)=[^&#]+)/ig,
         '');
   }
-  
+
   // Strip MailChimp parameters
   if (url.indexOf('mc_eid') > url.indexOf('?') || url.indexOf('mc_cid') > url.indexOf('?')) {
     url = url.replace(
@@ -16,7 +16,7 @@ function getStrippedUrl(url) {
   // Strip YouTube parameters
   if (url.indexOf('http://www.youtube.com/watch') == 0 ||
       url.indexOf('https://www.youtube.com/watch') == 0) {
-    url = url.replace(/([\?\&](feature|app)=[^&#]+)/ig, '');
+    url = url.replace(/([\?\&](feature|app|ac)=[^&#]*)/ig, '');
   }
 
   // If there were other query parameters, and the stripped ones were first,

--- a/extension/tests.html
+++ b/extension/tests.html
@@ -1,66 +1,12 @@
 <!DOCTYPE html>
 <html>
-<head>
-	<title>Unit Tests</title>
-	<script>
-	  // Stub so that background.js loads without errors.
-	  var chrome = {
-	    webNavigation: {
-	      onCompleted: {
-	        addListener: function() {}
-	      }
-	    }
-	  };
-	</script>
-  <script src="background.js"></script>
-  <script>
-    function log(msg, opt_color) {
-      var msgNode = document.createElement('div');
-      if (opt_color) {
-        msgNode.style.color = opt_color;
-      }
-      msgNode.innerText = msg;
-      document.getElementById('log').appendChild(msgNode);
-    }
+	<head>
+		<title>Unit Tests</title>
+		<script src="background.js"></script>
+		<script src="tests.js"></script>
+	</head>
 
-    function assertEquals(expected, actual, opt_msg) {
-      if (expected == actual) {
-        log('PASS: ' + expected + ' (as expected)');
-      } else {
-        var msg = opt_msg ? ' ' + opt_msg : '';
-        log('FAIL: ' + expected + ' (expected) != ' + actual + ' (actual)' + msg, 'red');
-      }
-    }
-
-    var TEST_DATA = {
-      'http://example.com/post': 'http://example.com/post',
-      'http://example.com/post?foo=bar': 'http://example.com/post?foo=bar',
-      'http://example.com/post?utm_source=src&utm_medium=medium&utm_campaign=campaign&utm_reader=feedly': 'http://example.com/post',
-      'http://example.com/post?mc_cid=1234&mc_eid=4321': 'http://example.com/post',
-      'http://example.com/post?foo=bar&utm_source=src': 'http://example.com/post?foo=bar',
-      'http://example.com/post?utm_source=src&foo=bar': 'http://example.com/post?foo=bar',
-      'http://example.com/post?utm_source=src#foo=bar': 'http://example.com/post#foo=bar',
-
-      'https://www.youtube.com/watch?v=YlGqN3AKOsA&feature=kp': 'https://www.youtube.com/watch?v=YlGqN3AKOsA',
-      'https://www.youtube.com/watch?feature=youtu.be&v=YlGqN3AKOsA': 'https://www.youtube.com/watch?v=YlGqN3AKOsA',
-      'http://www.youtube.com/watch?v=YlGqN3AKOsA&feature=kp': 'http://www.youtube.com/watch?v=YlGqN3AKOsA',
-      'http://www.youtube.com/watch?v=YlGqN3AKOsA&app=desktop': 'http://www.youtube.com/watch?v=YlGqN3AKOsA',
-      'http://www.youtube.com/watch?v=YlGqN3AKOsA&feature=kp&app=desktop': 'http://www.youtube.com/watch?v=YlGqN3AKOsA',
-      'http://www.youtube.com/watch?app=desktop&v=YlGqN3AKOsA': 'http://www.youtube.com/watch?v=YlGqN3AKOsA',
-      'http://www.youtube.com/watch?v=YlGqN3AKOsA&ac=': 'http://www.youtube.com/watch?v=YlGqN3AKOsA',
-      'http://www.youtube.com/watch?v=YlGqN3AKOsA&ac=test': 'http://www.youtube.com/watch?v=YlGqN3AKOsA',
-      'http://www.youtube.com/watch?ac=&v=YlGqN3AKOsA': 'http://www.youtube.com/watch?v=YlGqN3AKOsA',
-      'http://www.youtube.com/watch?v=YlGqN3AKOsA&ac=&app=desktop': 'http://www.youtube.com/watch?v=YlGqN3AKOsA',
-    }
-
-    function runTests() {
-      for (var input in TEST_DATA) {
-        assertEquals(TEST_DATA[input], getStrippedUrl(input));
-      }
-    }
-  </script>
-</head>
-<body onload="runTests()">
-  <pre id="log"></pre>
-</body>
+	<body>
+		<pre id="log"></pre>
+	</body>
 </html>

--- a/extension/tests.html
+++ b/extension/tests.html
@@ -46,7 +46,11 @@
       'http://www.youtube.com/watch?v=YlGqN3AKOsA&feature=kp': 'http://www.youtube.com/watch?v=YlGqN3AKOsA',
       'http://www.youtube.com/watch?v=YlGqN3AKOsA&app=desktop': 'http://www.youtube.com/watch?v=YlGqN3AKOsA',
       'http://www.youtube.com/watch?v=YlGqN3AKOsA&feature=kp&app=desktop': 'http://www.youtube.com/watch?v=YlGqN3AKOsA',
-      'http://www.youtube.com/watch?app=desktop&v=YlGqN3AKOsA': 'http://www.youtube.com/watch?v=YlGqN3AKOsA',      
+      'http://www.youtube.com/watch?app=desktop&v=YlGqN3AKOsA': 'http://www.youtube.com/watch?v=YlGqN3AKOsA',
+      'http://www.youtube.com/watch?v=YlGqN3AKOsA&ac=': 'http://www.youtube.com/watch?v=YlGqN3AKOsA',
+      'http://www.youtube.com/watch?v=YlGqN3AKOsA&ac=test': 'http://www.youtube.com/watch?v=YlGqN3AKOsA',
+      'http://www.youtube.com/watch?ac=&v=YlGqN3AKOsA': 'http://www.youtube.com/watch?v=YlGqN3AKOsA',
+      'http://www.youtube.com/watch?v=YlGqN3AKOsA&ac=&app=desktop': 'http://www.youtube.com/watch?v=YlGqN3AKOsA',
     }
 
     function runTests() {

--- a/extension/tests.js
+++ b/extension/tests.js
@@ -1,0 +1,46 @@
+function log(msg, opt_color) {
+  var msgNode = document.createElement('div');
+  if (opt_color) {
+	msgNode.style.color = opt_color;
+  }
+  msgNode.innerText = msg;
+  document.getElementById('log').appendChild(msgNode);
+}
+
+function assertEquals(expected, actual, opt_msg) {
+  if (expected == actual) {
+	log('PASS: ' + expected + ' (as expected)');
+  } else {
+	var msg = opt_msg ? ' ' + opt_msg : '';
+	log('FAIL: ' + expected + ' (expected) != ' + actual + ' (actual)' + msg, 'red');
+  }
+}
+
+var TEST_DATA = {
+  'http://example.com/post': 'http://example.com/post',
+  'http://example.com/post?foo=bar': 'http://example.com/post?foo=bar',
+  'http://example.com/post?utm_source=src&utm_medium=medium&utm_campaign=campaign&utm_reader=feedly': 'http://example.com/post',
+  'http://example.com/post?mc_cid=1234&mc_eid=4321': 'http://example.com/post',
+  'http://example.com/post?foo=bar&utm_source=src': 'http://example.com/post?foo=bar',
+  'http://example.com/post?utm_source=src&foo=bar': 'http://example.com/post?foo=bar',
+  'http://example.com/post?utm_source=src#foo=bar': 'http://example.com/post#foo=bar',
+
+  'https://www.youtube.com/watch?v=YlGqN3AKOsA&feature=kp': 'https://www.youtube.com/watch?v=YlGqN3AKOsA',
+  'https://www.youtube.com/watch?feature=youtu.be&v=YlGqN3AKOsA': 'https://www.youtube.com/watch?v=YlGqN3AKOsA',
+  'http://www.youtube.com/watch?v=YlGqN3AKOsA&feature=kp': 'http://www.youtube.com/watch?v=YlGqN3AKOsA',
+  'http://www.youtube.com/watch?v=YlGqN3AKOsA&app=desktop': 'http://www.youtube.com/watch?v=YlGqN3AKOsA',
+  'http://www.youtube.com/watch?v=YlGqN3AKOsA&feature=kp&app=desktop': 'http://www.youtube.com/watch?v=YlGqN3AKOsA',
+  'http://www.youtube.com/watch?app=desktop&v=YlGqN3AKOsA': 'http://www.youtube.com/watch?v=YlGqN3AKOsA',
+  'http://www.youtube.com/watch?v=YlGqN3AKOsA&ac=': 'http://www.youtube.com/watch?v=YlGqN3AKOsA',
+  'http://www.youtube.com/watch?v=YlGqN3AKOsA&ac=test': 'http://www.youtube.com/watch?v=YlGqN3AKOsA',
+  'http://www.youtube.com/watch?ac=&v=YlGqN3AKOsA': 'http://www.youtube.com/watch?v=YlGqN3AKOsA',
+  'http://www.youtube.com/watch?v=YlGqN3AKOsA&ac=&app=desktop': 'http://www.youtube.com/watch?v=YlGqN3AKOsA',
+}
+
+function runTests() {
+  for (var input in TEST_DATA) {
+	assertEquals(TEST_DATA[input], getStrippedUrl(input));
+  }
+}
+
+window.addEventListener('load', runTests, false);


### PR DESCRIPTION
I visited a YouTube link and it had the 'ac' parameter. I don't know what it's used for and it didn't have a value. I've changed the regex to strip it.

I also fixed the test page.