### PR TITLE
Strip src_vid and annotation_id from YouTube URLs

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -16,7 +16,7 @@ function getStrippedUrl(url) {
   // Strip YouTube parameters
   if (url.indexOf('http://www.youtube.com/watch') == 0 ||
       url.indexOf('https://www.youtube.com/watch') == 0) {
-    url = url.replace(/([\?\&](feature|app|ac)=[^&#]*)/ig, '');
+    url = url.replace(/([\?\&](feature|app|ac|src_vid|annotation_id)=[^&#]*)/ig, '');
   }
 
   // If there were other query parameters, and the stripped ones were first,

--- a/extension/tests.js
+++ b/extension/tests.js
@@ -35,6 +35,7 @@ var TEST_DATA = {
   'http://www.youtube.com/watch?v=YlGqN3AKOsA&ac=test': 'http://www.youtube.com/watch?v=YlGqN3AKOsA',
   'http://www.youtube.com/watch?ac=&v=YlGqN3AKOsA': 'http://www.youtube.com/watch?v=YlGqN3AKOsA',
   'http://www.youtube.com/watch?v=YlGqN3AKOsA&ac=&app=desktop': 'http://www.youtube.com/watch?v=YlGqN3AKOsA',
+  'https://www.youtube.com/watch?v=3OHBlPvK9Ek&src_vid=4KHCkXN2F8I&annotation_id=annotation_1193924099': 'https://www.youtube.com/watch?v=3OHBlPvK9Ek',
 }
 
 function runTests() {


### PR DESCRIPTION
Both are added when you click on an annotation on a video which links
to another video