### PR TITLE
strip HubSpot parameters

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -24,6 +24,13 @@ function getStrippedUrl(url) {
     url = url.replace(/([\?\&]_openstat=[^&#]+)/ig, '');
   }
 
+  // Strip HubSpot parameters
+  if (url.indexOf('_hsenc') > url.indexOf('?') || url.indexOf('_hsmi') > url.indexOf('?')) {
+    url = url.replace(
+        /([\?\&](_hsenc|_hsmi)=[^&#]+)/ig,
+        '');
+  }
+
   // If there were other query parameters, and the stripped ones were first,
   // then we need to convert the first ampersand to a ? to still have a valid
   // URL.
@@ -52,6 +59,8 @@ chrome.webNavigation.onDOMContentLoaded.addListener(
       {queryContains: 'utm_'},
       {queryContains: 'mc_cid'},
       {queryContains: 'mc_eid'},
+      {queryContains: '_hsmi'},
+      {queryContains: '_hsenc'},
       {hostEquals: 'www.youtube.com', pathPrefix: '/watch'},
     ]
   });

--- a/extension/tests.js
+++ b/extension/tests.js
@@ -42,6 +42,9 @@ var TEST_DATA = {
   'http://www.site.ru/path?foo=bar&_openstat=ZGlyZWN0LnlhbmRleC5ydTsxMjM0OzU2Nzg5O3lhbmRleC5ydTpwcmVtaXVt': 'http://www.site.ru/path?foo=bar',
   'http://www.site.ru/path?_openstat=ZGlyZWN0LnlhbmRleC5ydTsxMjM0OzU2Nzg5O3lhbmRleC5ydTpwcmVtaXVt&foo=bar': 'http://www.site.ru/path?foo=bar',
   'http://www.site.ru/path?_openstat=ZGlyZWN0LnlhbmRleC5ydTsxMjM0OzU2Nzg5O3lhbmRleC5ydTpwcmVtaXVt#fragment': 'http://www.site.ru/path#fragment',
+
+  'http://www.site.ru/path?_hsenc=p2ANqtz-_j2noaLd_iaXBsfMnXE4ZUzjZUXO24HCCJkm&_hsmi=27699104': 'http://www.site.ru/path',
+  'http://www.site.ru/path?_hsenc=p2ANqtz-_j2noaLd_iaXBsfMnXE4ZUzjZUXO24HCCJkm&_hsmi=27699104#fragment': 'http://www.site.ru/path#fragment',
 }
 
 function runTests() {


### PR DESCRIPTION
This strips [HubSpot parameters](http://knowledge.hubspot.com/articles/kcs_article/reports/why-do-i-see-so-many-urls-for-the-same-page-in-google-analytics-for-visits-from-hubspot-emails). I've been starting to see these more and more frequently.
